### PR TITLE
build: Add a meson build option to add linux kernel header path

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,3 +1,9 @@
-vfn_inc = include_directories('.')
+vfn_inc_strs=['.']
+kernel_header_path = get_option('kernel-header-path')
+if kernel_header_path != ''
+  vfn_inc_strs += [kernel_header_path]
+endif
+
+vfn_inc = include_directories(vfn_inc_strs)
 
 subdir('vfn')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,6 @@ option('docs', type: 'feature', value: 'auto',
 
 option('trace-events-file', type: 'string', value: 'config/trace-events-all',
   description: 'trace events file')
+
+option('kernel-header-path', type: 'string', value: '',
+  description: 'Path to kernel headers that you want to use for the build')


### PR DESCRIPTION
One might need to point the build to a linux kernel include directory different from the one that is currently installed. To avoid having to constantly install the linux kernel headers on the system, we add a meson build option that adds a user defined path to the include paths of the project.