### PR TITLE
Support for vfio close

### DIFF
--- a/include/vfn/vfio/pci.h
+++ b/include/vfn/vfio/pci.h
@@ -48,6 +48,17 @@ struct vfio_pci_device {
 int vfio_pci_open(struct vfio_pci_device *pci, const char *bdf);
 
 /**
+ * vfio_pci_close - close vfio device file descriptor
+ * @pci: &struct vfio_pci_device whose fd is to close
+ *
+ * Close vfio group file descriptor
+ *
+ * Return: On success, returns ``0``. On error, returns ``-1`` and sets
+ * ``errno``.
+ */
+int vfio_pci_close(struct vfio_pci_device *pci);
+
+/**
  * vfio_pci_map_bar - map a vfio device region into virtual memory
  * @pci: &struct vfio_pci_device
  * @idx: the vfio region index to map

--- a/src/iommu/context.h
+++ b/src/iommu/context.h
@@ -26,6 +26,7 @@ struct iommu_ctx_ops {
 
 	/* device ops */
 	int (*get_device_fd)(struct iommu_ctx *ctx, const char *bdf);
+	int (*put_device_fd)(struct iommu_ctx *ctx, const char *bdf);
 };
 
 struct iova_mapping {

--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -37,6 +37,7 @@
 #include "vfn/iommu.h"
 
 #include "ccan/list/list.h"
+#include "ccan/compiler/compiler.h"
 
 #include "context.h"
 #include "trace.h"
@@ -48,6 +49,7 @@ struct iommu_ioas {
 
 	char *name;
 	uint32_t id;
+	int devfd;
 };
 
 static struct iommu_ioas iommufd_default_ioas = {
@@ -147,12 +149,26 @@ static int iommufd_get_device_fd(struct iommu_ctx *ctx, const char *bdf)
 		goto close_dev;
 	}
 
+	ioas->devfd = devfd;
 	return devfd;
 
 close_dev:
 	/* closing devfd will automatically unbind it from iommufd */
 	log_fatal_if(close(devfd), "close: %s\n", strerror(errno));
 
+	return -1;
+}
+
+static int iommufd_put_device_fd(struct iommu_ctx *ctx, const char *bdf UNUSED)
+{
+	struct iommu_ioas *ioas = container_of_var(ctx, ioas, ctx);
+
+	if (ioas->devfd) {
+		close(ioas->devfd);
+		return 0;
+	}
+
+	errno = ENODEV;
 	return -1;
 }
 
@@ -234,6 +250,7 @@ static int iommu_ioas_do_dma_unmap_all(struct iommu_ctx *ctx)
 
 static const struct iommu_ctx_ops iommufd_ops = {
 	.get_device_fd = iommufd_get_device_fd,
+	.put_device_fd = iommufd_put_device_fd,
 
 	.dma_map = iommu_ioas_do_dma_map,
 	.dma_unmap = iommu_ioas_do_dma_unmap,

--- a/src/nvme/core.c
+++ b/src/nvme/core.c
@@ -681,5 +681,5 @@ void nvme_close(struct nvme_ctrl *ctrl)
 	vfio_pci_unmap_bar(&ctrl->pci, 0, ctrl->regs, 0x1000, 0);
 	vfio_pci_unmap_bar(&ctrl->pci, 0, ctrl->doorbells, 0x1000, 0x1000);
 
-	//vfio_close(ctrl->pci.vfio);
+	vfio_pci_close(&ctrl->pci);
 }

--- a/src/vfio/pci.c
+++ b/src/vfio/pci.c
@@ -188,3 +188,12 @@ int vfio_pci_open(struct vfio_pci_device *pci, const char *bdf)
 
 	return 0;
 }
+
+int vfio_pci_close(struct vfio_pci_device *pci)
+{
+	struct iommu_ctx *ctx = pci->dev.ctx;
+
+	close(pci->dev.fd);
+
+	return ctx->ops.put_device_fd(ctx, pci->bdf);
+}


### PR DESCRIPTION
Users (e.g.,application) might want to open and close the vfio PCI device in
the same process context.  This series added vfio pci close helpers.