### PR TITLE
Prep for DriverKit

### DIFF
--- a/include/vfn/iommu/dmabuf.h
+++ b/include/vfn/iommu/dmabuf.h
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later or MIT */
+
+/*
+ * This file is part of libvfn.
+ *
+ * Copyright (C) 2023 The libvfn Authors. All Rights Reserved.
+ *
+ * This library (libvfn) is dual licensed under the GNU Lesser General
+ * Public License version 2.1 or later or the MIT license. See the
+ * COPYING and LICENSE files for more information.
+ */
+
+#ifndef LIBVFN_IOMMU_DMABUF_H
+#define LIBVFN_IOMMU_DMABUF_H
+
+/**
+ * DOC: DMA-buffer helpers
+ *
+ * This provides a helper for allocating and mapping DMA buffers.
+ *
+ * &struct iommu_dmabuf is also registered as an "autovar" and can be
+ * automatically unmapped and deallocated when going out of scope. For this
+ * reason, this header is not included in <vfn/iommu.h> and must explicitly be
+ * included.
+ *
+ * Required includes:
+ *   #include <vfn/iommu.h>
+ *   #include <vfn/support/autoptr.h>
+ *   #include <vfn/iommu/dmabuf.h>
+ */
+
+
+/**
+ * struct iommu_dmabuf - DMA buffer abstraction
+ * @ctx: &struct iommu_ctx
+ * @vaddr: data buffer
+ * @iova: mapped address
+ * @len: length of @vaddr
+ *
+ * Convenience wrapper around a mapped data buffer.
+ */
+struct iommu_dmabuf {
+	struct iommu_ctx *ctx;
+
+	void *vaddr;
+	uint64_t iova;
+	ssize_t len;
+};
+
+/**
+ * iommu_get_dmabuf - Allocate and map a DMA buffer
+ * @ctx: &struct iommu_ctx
+ * @buffer: uninitialized &struct iommu_dmabuf
+ * @len: desired minimum length
+ * @flags: combination of enum iommu_map_flags
+ *
+ * Allocate at least @len bytes and map the buffer within the IOVA address space
+ * described by @ctx. The actual allocated and mapped length may be larger than
+ * requestes due to alignment requirements.
+ *
+ * Return: On success, returns ``0``; on error, returns ``-1`` and sets
+ * ``errno``.
+ */
+int iommu_get_dmabuf(struct iommu_ctx *ctx, struct iommu_dmabuf *buffer, size_t len,
+		     unsigned long flags);
+
+/**
+ * iommu_put_dmabuf - Unmap and deallocate a DMA buffer
+ * @buffer: &struct iommu_dmabuf
+ *
+ * Unmap the buffer and deallocate it.
+ */
+void iommu_put_dmabuf(struct iommu_dmabuf *buffer);
+
+static inline void __do_iommu_put_dmabuf(void *p)
+{
+	struct iommu_dmabuf *buffer = (struct iommu_dmabuf *)p;
+
+	iommu_put_dmabuf(buffer);
+}
+
+DEFINE_AUTOVAR_STRUCT(iommu_dmabuf, __do_iommu_put_dmabuf);
+
+#endif /* LIBVFN_IOMMU_DMABUF_H */

--- a/include/vfn/nvme.h
+++ b/include/vfn/nvme.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <vfn/trace.h>
 #include <vfn/trace/events.h>
 #include <vfn/iommu.h>
+#include <vfn/iommu/dmabuf.h>
 #include <vfn/vfio.h>
 #include <vfn/nvme/types.h>
 #include <vfn/nvme/queue.h>

--- a/include/vfn/nvme/ctrl.h
+++ b/include/vfn/nvme/ctrl.h
@@ -82,8 +82,8 @@ struct nvme_ctrl {
 	 * @dbbuf: doorbell buffers
 	 */
 	struct {
-		void *doorbells;
-		void *eventidxs;
+		struct iommu_dmabuf doorbells;
+		struct iommu_dmabuf eventidxs;
 	} dbbuf;
 
 	/**

--- a/include/vfn/nvme/util.h
+++ b/include/vfn/nvme/util.h
@@ -55,7 +55,12 @@ static inline bool nvme_cqe_ok(struct nvme_cqe *cqe)
  *
  * Return: ``0`` when no error in @cqe, otherwise ``-1`` and set ``errno``.
  */
-int nvme_set_errno_from_cqe(struct nvme_cqe *cqe);
+static inline int nvme_set_errno_from_cqe(struct nvme_cqe *cqe)
+{
+	errno = le16_to_cpu(cqe->sfp) >> 1 ? EIO : 0;
+
+	return errno ? -1 : 0;
+}
 
 /**
  * nvme_aer - Submit an Asynchronous Event Request command

--- a/include/vfn/support/autoptr.h
+++ b/include/vfn/support/autoptr.h
@@ -14,11 +14,11 @@
 #define LIBVFN_SUPPORT_AUTOPTR_H
 
 /**
- * DOC: glib-style auto pointer
+ * DOC: glib-style automatic cleanup.
  *
- * The __autoptr() provides a general way of "cleaning up" when going out of
- * scope. Inspired by glib, but simplified a lot (at the expence of
- * flexibility).
+ * The __autoptr() and __autovar_s() provides a general way of "cleaning up"
+ * when going out of scope. Inspired by glib, but simplified a lot (at the
+ * expence of flexibility).
  */
 
 #define __AUTOPTR_CLEANUP(t) __autoptr_cleanup_##t
@@ -27,7 +27,7 @@
 /**
  * DEFINE_AUTOPTR - Defines the appropriate cleanup function for a pointer type
  * @t: type name
- * @cleanup: function to be called to cleanup type
+ * @cleanup: function to be called to clean up type
  *
  * Defines a function ``__autoptr_cleanup_##t`` that will call @cleanup when
  * invoked.
@@ -50,5 +50,35 @@
  * DEFINE_AUTOPTR().
  */
 #define __autoptr(t) __attribute__((cleanup(__AUTOPTR_CLEANUP(t)))) __AUTOPTR_T(t)
+
+#define __AUTOVAR_STRUCT_CLEANUP(t) __autovar_struct_cleanup_##t
+#define __AUTOVAR_STRUCT_T(t) __autovar_struct_##t
+
+/**
+ * DEFINE_AUTOVAR_STRUCT - Defines the appropriate cleanup function for a struct
+ *                         type
+ * @t: type name
+ * @cleanup: function to be called to clean up type
+ *
+ * Defines a function ``__autovar_struct_cleanup_##t`` that will call @cleanup
+ * when invoked.
+ */
+#define DEFINE_AUTOVAR_STRUCT(t, cleanup) \
+	typedef struct t __AUTOVAR_STRUCT_T(t); \
+	\
+	static inline void __AUTOVAR_STRUCT_CLEANUP(t) (struct t *p) \
+	{ \
+		(cleanup)(p); \
+	}
+
+/**
+ * __autovar_s - Helper to declare a struct variable with automatic cleanup
+ * @t: type name
+ *
+ * Declares a struct-type variable that is cleaned up when the variable goes out
+ * of scope.  How to clean up the type must have been previously declared using
+ * DEFINE_AUTOPTR().
+ */
+#define __autovar_s(t) __attribute__((cleanup(__AUTOVAR_STRUCT_CLEANUP(t)))) __AUTOVAR_STRUCT_T(t)
 
 #endif /* LIBVFN_SUPPORT_AUTOPTR_H */

--- a/src/iommu/dmabuf.c
+++ b/src/iommu/dmabuf.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later or MIT
+
+/*
+ * This file is part of libvfn.
+ *
+ * Copyright (C) 2024 The libvfn Authors. All Rights Reserved.
+ *
+ * This library (libvfn) is dual licensed under the GNU Lesser General
+ * Public License version 2.1 or later or the MIT license. See the
+ * COPYING and LICENSE files for more information.
+ */
+
+#include <string.h>
+
+#include <sys/types.h>
+
+#include <vfn/iommu.h>
+
+#include <vfn/support/autoptr.h>
+#include <vfn/iommu/dmabuf.h>
+
+#include <vfn/support.h>
+
+int iommu_get_dmabuf(struct iommu_ctx *ctx, struct iommu_dmabuf *buffer, size_t len,
+		     unsigned long flags)
+{
+	buffer->ctx = ctx;
+
+	buffer->len = pgmap(&buffer->vaddr, len);
+	if (buffer->len < 0)
+		return -1;
+
+	if (iommu_map_vaddr(ctx, buffer->vaddr, buffer->len, &buffer->iova, flags)) {
+		pgunmap(buffer->vaddr, buffer->len);
+		return -1;
+	}
+
+	return 0;
+}
+
+void iommu_put_dmabuf(struct iommu_dmabuf *buffer)
+{
+	if (!buffer->len)
+		return;
+
+	log_fatal_if(iommu_unmap_vaddr(buffer->ctx, buffer->vaddr, NULL), "iommu_unmap_vaddr");
+
+	pgunmap(buffer->vaddr, buffer->len);
+
+	memset(buffer, 0x0, sizeof(*buffer));
+}

--- a/src/iommu/meson.build
+++ b/src/iommu/meson.build
@@ -1,6 +1,7 @@
 iommu_sources = files(
   'context.c',
   'dma.c',
+  'dmabuf.c',
   'vfio.c',
 )
 

--- a/src/nvme/core.c
+++ b/src/nvme/core.c
@@ -33,7 +33,6 @@
 #include <vfn/trace.h>
 #include <vfn/iommu.h>
 #include <vfn/vfio.h>
-#include <vfn/iommu.h>
 #include <vfn/pci.h>
 #include <vfn/nvme.h>
 
@@ -115,7 +114,6 @@ static int nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize, int vec
 	struct nvme_cq *cq = &ctrl->cq[qid];
 	uint64_t cap;
 	uint8_t dstrd;
-	size_t len;
 
 	cap = le64_to_cpu(mmio_read64(ctrl->regs + NVME_REG_CAP));
 	dstrd = NVME_FIELD_GET(cap, CAP_DSTRD);
@@ -144,36 +142,25 @@ static int nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize, int vec
 		.vector = vector,
 	};
 
-	if (ctrl->dbbuf.doorbells) {
-		cq->dbbuf.doorbell = cqhdbl(ctrl->dbbuf.doorbells, qid, dstrd);
-		cq->dbbuf.eventidx = cqhdbl(ctrl->dbbuf.eventidxs, qid, dstrd);
+	if (ctrl->dbbuf.doorbells.vaddr) {
+		cq->dbbuf.doorbell = cqhdbl(ctrl->dbbuf.doorbells.vaddr, qid, dstrd);
+		cq->dbbuf.eventidx = cqhdbl(ctrl->dbbuf.eventidxs.vaddr, qid, dstrd);
 	}
 
-	len = pgmapn(&cq->vaddr, qsize, 1 << NVME_CQES);
-
-	if (iommu_map_vaddr(__iommu_ctx(ctrl), cq->vaddr, len, &cq->iova, 0x0)) {
-		log_debug("failed to map vaddr\n");
-
-		pgunmap(cq->vaddr, len);
+	if (iommu_get_dmabuf(__iommu_ctx(ctrl), &cq->mem, qsize << NVME_CQES, 0x0))
 		return -1;
-	}
 
 	return 0;
 }
 
 void nvme_discard_cq(struct nvme_ctrl *ctrl, struct nvme_cq *cq)
 {
-	size_t len;
-
-	if (!cq->vaddr)
+	if (!cq->mem.vaddr)
 		return;
 
-	if (iommu_unmap_vaddr(__iommu_ctx(ctrl), cq->vaddr, &len))
-		log_debug("failed to unmap vaddr\n");
+	iommu_put_dmabuf(&cq->mem);
 
-	pgunmap(cq->vaddr, len);
-
-	if (ctrl->dbbuf.doorbells) {
+	if (ctrl->dbbuf.doorbells.vaddr) {
 		__STORE_PTR(uint32_t *, cq->dbbuf.doorbell, 0);
 		__STORE_PTR(uint32_t *, cq->dbbuf.eventidx, 0);
 	}
@@ -187,7 +174,9 @@ static int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
 	struct nvme_sq *sq = &ctrl->sq[qid];
 	uint64_t cap;
 	uint8_t dstrd;
-	ssize_t len;
+	size_t pagesize;
+
+	pagesize = __mps_to_pagesize(ctrl->config.mps);
 
 	cap = le64_to_cpu(mmio_read64(ctrl->regs + NVME_REG_CAP));
 	dstrd = NVME_FIELD_GET(cap, CAP_DSTRD);
@@ -216,24 +205,17 @@ static int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
 		.cq = cq,
 	};
 
-	if (ctrl->dbbuf.doorbells) {
-		sq->dbbuf.doorbell = sqtdbl(ctrl->dbbuf.doorbells, qid, dstrd);
-		sq->dbbuf.eventidx = sqtdbl(ctrl->dbbuf.eventidxs, qid, dstrd);
+	if (ctrl->dbbuf.doorbells.vaddr) {
+		sq->dbbuf.doorbell = sqtdbl(ctrl->dbbuf.doorbells.vaddr, qid, dstrd);
+		sq->dbbuf.eventidx = sqtdbl(ctrl->dbbuf.eventidxs.vaddr, qid, dstrd);
 	}
 
 	/*
 	 * Use ctrl->config.mps instead of host page size, as we have the
 	 * opportunity to pack the allocations.
 	 */
-	len = pgmapn(&sq->pages.vaddr, qsize, __mps_to_pagesize(ctrl->config.mps));
-
-	if (len < 0)
+	if (iommu_get_dmabuf(__iommu_ctx(ctrl), &sq->pages, pagesize, 0x0))
 		return -1;
-
-	if (iommu_map_vaddr(__iommu_ctx(ctrl), sq->pages.vaddr, len, &sq->pages.iova, 0x0)) {
-		log_debug("failed to map vaddr\n");
-		goto unmap_pages;
-	}
 
 	sq->rqs = znew_t(struct nvme_rq, qsize - 1);
 	sq->rq_top = &sq->rqs[qsize - 2];
@@ -251,50 +233,28 @@ static int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
 			rq->rq_next = &sq->rqs[i - 1];
 	}
 
-	len = pgmapn(&sq->vaddr, qsize, 1 << NVME_SQES);
-	if (len < 0)
-		goto free_sq_rqs;
+	if (iommu_get_dmabuf(__iommu_ctx(ctrl), &sq->mem, qsize << NVME_SQES, 0x0)) {
+		free(sq->rqs);
+		iommu_put_dmabuf(&sq->pages);
 
-	if (iommu_map_vaddr(__iommu_ctx(ctrl), sq->vaddr, len, &sq->iova, 0x0)) {
-		log_debug("failed to map vaddr\n");
-		goto unmap_sq;
+		return -1;
 	}
 
 	return 0;
-
-unmap_sq:
-	pgunmap(sq->vaddr, len);
-free_sq_rqs:
-	free(sq->rqs);
-unmap_pages:
-	if (iommu_unmap_vaddr(__iommu_ctx(ctrl), sq->pages.vaddr, (size_t *)&len))
-		log_debug("failed to unmap vaddr\n");
-
-	pgunmap(sq->pages.vaddr, len);
-
-	return -1;
 }
 
 void nvme_discard_sq(struct nvme_ctrl *ctrl, struct nvme_sq *sq)
 {
-	size_t len;
-
-	if (!sq->vaddr)
+	if (!sq->mem.vaddr)
 		return;
 
-	if (iommu_unmap_vaddr(__iommu_ctx(ctrl), sq->vaddr, &len))
-		log_debug("failed to unmap vaddr\n");
-
-	pgunmap(sq->vaddr, len);
+	iommu_put_dmabuf(&sq->mem);
 
 	free(sq->rqs);
 
-	if (iommu_unmap_vaddr(__iommu_ctx(ctrl), sq->pages.vaddr, &len))
-		log_debug("failed to unmap vaddr\n");
+	iommu_put_dmabuf(&sq->pages);
 
-	pgunmap(sq->pages.vaddr, len);
-
-	if (ctrl->dbbuf.doorbells) {
+	if (ctrl->dbbuf.doorbells.vaddr) {
 		__STORE_PTR(uint32_t *, sq->dbbuf.doorbell, 0);
 		__STORE_PTR(uint32_t *, sq->dbbuf.eventidx, 0);
 	}
@@ -326,8 +286,8 @@ int nvme_configure_adminq(struct nvme_ctrl *ctrl, unsigned long sq_flags)
 	aqa |= aqa << 16;
 
 	mmio_write32(ctrl->regs + NVME_REG_AQA, cpu_to_le32(aqa));
-	mmio_hl_write64(ctrl->regs + NVME_REG_ASQ, cpu_to_le64(sq->iova));
-	mmio_hl_write64(ctrl->regs + NVME_REG_ACQ, cpu_to_le64(cq->iova));
+	mmio_hl_write64(ctrl->regs + NVME_REG_ASQ, cpu_to_le64(sq->mem.iova));
+	mmio_hl_write64(ctrl->regs + NVME_REG_ACQ, cpu_to_le64(cq->mem.iova));
 
 	return 0;
 
@@ -361,7 +321,7 @@ int nvme_create_iocq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector)
 
 	cmd.create_cq = (struct nvme_cmd_create_cq) {
 		.opcode = NVME_ADMIN_CREATE_CQ,
-		.prp1   = cpu_to_le64(cq->iova),
+		.prp1   = cpu_to_le64(cq->mem.iova),
 		.qid    = cpu_to_le16((uint16_t)qid),
 		.qsize  = cpu_to_le16((uint16_t)(qsize - 1)),
 		.qflags = cpu_to_le16(qflags),
@@ -398,7 +358,7 @@ int nvme_create_iosq(struct nvme_ctrl *ctrl, int qid, int qsize, struct nvme_cq 
 
 	cmd.create_sq = (struct nvme_cmd_create_sq) {
 		.opcode = NVME_ADMIN_CREATE_SQ,
-		.prp1   = cpu_to_le64(sq->iova),
+		.prp1   = cpu_to_le64(sq->mem.iova),
 		.qid    = cpu_to_le16((uint16_t)qid),
 		.qsize  = cpu_to_le16((uint16_t)(qsize - 1)),
 		.qflags = cpu_to_le16(NVME_Q_PC),
@@ -518,29 +478,22 @@ int nvme_reset(struct nvme_ctrl *ctrl)
 
 static int nvme_init_dbconfig(struct nvme_ctrl *ctrl)
 {
-	uint64_t prp1, prp2;
 	union nvme_cmd cmd;
 
-	if (pgmap((void **)&ctrl->dbbuf.doorbells, __VFN_PAGESIZE) < 0)
+	if (iommu_get_dmabuf(__iommu_ctx(ctrl), &ctrl->dbbuf.doorbells, __VFN_PAGESIZE, 0x0))
 		return -1;
 
-	if (iommu_map_vaddr(__iommu_ctx(ctrl), ctrl->dbbuf.doorbells, __VFN_PAGESIZE, &prp1, 0x0))
-		return -1;
-
-	if (pgmap((void **)&ctrl->dbbuf.eventidxs, __VFN_PAGESIZE) < 0)
-		return -1;
-
-	if (iommu_map_vaddr(__iommu_ctx(ctrl), ctrl->dbbuf.eventidxs, __VFN_PAGESIZE, &prp2, 0x0))
-		return -1;
+	if (iommu_get_dmabuf(__iommu_ctx(ctrl), &ctrl->dbbuf.eventidxs, __VFN_PAGESIZE, 0x0))
+		goto put_doorbells;
 
 	cmd = (union nvme_cmd) {
 		.opcode = NVME_ADMIN_DBCONFIG,
-		.dptr.prp1 = cpu_to_le64(prp1),
-		.dptr.prp2 = cpu_to_le64(prp2),
+		.dptr.prp1 = cpu_to_le64(ctrl->dbbuf.doorbells.iova),
+		.dptr.prp2 = cpu_to_le64(ctrl->dbbuf.eventidxs.iova),
 	};
 
 	if (__admin(ctrl, &cmd))
-		return -1;
+		goto put_eventidxs;
 
 	if (!(ctrl->opts.quirks & NVME_QUIRK_BROKEN_DBBUF)) {
 		uint64_t cap;
@@ -549,14 +502,25 @@ static int nvme_init_dbconfig(struct nvme_ctrl *ctrl)
 		cap = le64_to_cpu(mmio_read64(ctrl->regs + NVME_REG_CAP));
 		dstrd = NVME_FIELD_GET(cap, CAP_DSTRD);
 
-		ctrl->adminq.cq->dbbuf.doorbell = cqhdbl(ctrl->dbbuf.doorbells, NVME_AQ, dstrd);
-		ctrl->adminq.cq->dbbuf.eventidx = cqhdbl(ctrl->dbbuf.eventidxs, NVME_AQ, dstrd);
+		ctrl->adminq.cq->dbbuf.doorbell =
+			cqhdbl(ctrl->dbbuf.doorbells.vaddr, NVME_AQ, dstrd);
+		ctrl->adminq.cq->dbbuf.eventidx =
+			cqhdbl(ctrl->dbbuf.eventidxs.vaddr, NVME_AQ, dstrd);
 
-		ctrl->adminq.sq->dbbuf.doorbell = sqtdbl(ctrl->dbbuf.doorbells, NVME_AQ, dstrd);
-		ctrl->adminq.sq->dbbuf.eventidx = sqtdbl(ctrl->dbbuf.eventidxs, NVME_AQ, dstrd);
+		ctrl->adminq.sq->dbbuf.doorbell =
+			sqtdbl(ctrl->dbbuf.doorbells.vaddr, NVME_AQ, dstrd);
+		ctrl->adminq.sq->dbbuf.eventidx =
+			sqtdbl(ctrl->dbbuf.eventidxs.vaddr, NVME_AQ, dstrd);
 	}
 
 	return 0;
+
+put_eventidxs:
+	iommu_put_dmabuf(&ctrl->dbbuf.eventidxs);
+put_doorbells:
+	iommu_put_dmabuf(&ctrl->dbbuf.doorbells);
+
+	return -1;
 }
 
 static int nvme_init_pci(struct nvme_ctrl *ctrl, const char *bdf)
@@ -639,11 +603,12 @@ int nvme_ctrl_init(struct nvme_ctrl *ctrl, const char *bdf,
 
 int nvme_init(struct nvme_ctrl *ctrl, const char *bdf, const struct nvme_ctrl_opts *opts)
 {
+	struct iommu_ctx *ctx = __iommu_ctx(ctrl);
+
 	uint16_t oacs;
 	uint32_t sgls;
-	ssize_t len;
-	void *vaddr;
-	int ret;
+
+	__autovar_s(iommu_dmabuf) buffer;
 
 	union nvme_cmd cmd = {};
 	struct nvme_cqe cqe;
@@ -688,8 +653,7 @@ int nvme_init(struct nvme_ctrl *ctrl, const char *bdf, const struct nvme_ctrl_op
 	ctrl->config.ncqa = min_t(int, ctrl->opts.ncqr,
 				  NVME_FIELD_GET(le32_to_cpu(cqe.dw0), FEAT_NRQS_NCQR));
 
-	len = pgmap(&vaddr, NVME_IDENTIFY_DATA_SIZE);
-	if (len < 0)
+	if (iommu_get_dmabuf(ctx, &buffer, NVME_IDENTIFY_DATA_SIZE, IOMMU_MAP_EPHEMERAL))
 		return -1;
 
 	cmd.identify = (struct nvme_cmd_identify) {
@@ -697,17 +661,14 @@ int nvme_init(struct nvme_ctrl *ctrl, const char *bdf, const struct nvme_ctrl_op
 		.cns = NVME_IDENTIFY_CNS_CTRL,
 	};
 
-	ret = nvme_admin(ctrl, &cmd, vaddr, len, NULL);
-	if (ret) {
-		log_debug("could not identify\n");
-		goto out;
-	}
+	if (nvme_admin(ctrl, &cmd, buffer.vaddr, buffer.len, NULL))
+		return -1;
 
-	oacs = le16_to_cpu(*(leint16_t *)(vaddr + NVME_IDENTIFY_CTRL_OACS));
-	if (oacs & NVME_IDENTIFY_CTRL_OACS_DBCONFIG)
-		ret = nvme_init_dbconfig(ctrl);
+	oacs = le16_to_cpu(*(leint16_t *)(buffer.vaddr + NVME_IDENTIFY_CTRL_OACS));
+	if (oacs & NVME_IDENTIFY_CTRL_OACS_DBCONFIG && nvme_init_dbconfig(ctrl))
+		return -1;
 
-	sgls = le32_to_cpu(*(leint32_t *)(vaddr + NVME_IDENTIFY_CTRL_SGLS));
+	sgls = le32_to_cpu(*(leint32_t *)(buffer.vaddr + NVME_IDENTIFY_CTRL_SGLS));
 	if (sgls) {
 		uint32_t alignment = NVME_FIELD_GET(sgls, IDENTIFY_CTRL_SGLS_ALIGNMENT);
 
@@ -717,10 +678,7 @@ int nvme_init(struct nvme_ctrl *ctrl, const char *bdf, const struct nvme_ctrl_op
 			ctrl->flags |= NVME_CTRL_F_SGLS_DWORD_ALIGNMENT;
 	}
 
-out:
-	pgunmap(vaddr, len);
-
-	return ret;
+	return 0;
 }
 
 void nvme_close(struct nvme_ctrl *ctrl)
@@ -735,17 +693,9 @@ void nvme_close(struct nvme_ctrl *ctrl)
 
 	free(ctrl->cq);
 
-	if (ctrl->dbbuf.doorbells) {
-		struct iommu_ctx *ctx = __iommu_ctx(ctrl);
-		size_t len;
-
-		log_fatal_if(iommu_unmap_vaddr(ctx, ctrl->dbbuf.doorbells, &len),
-			     "iommu_unmap_vaddr");
-		pgunmap(ctrl->dbbuf.doorbells, len);
-
-		log_fatal_if(iommu_unmap_vaddr(ctx, ctrl->dbbuf.eventidxs, &len),
-			     "iommu_unmap_vaddr");
-		pgunmap(ctrl->dbbuf.eventidxs, len);
+	if (ctrl->dbbuf.doorbells.vaddr) {
+		iommu_put_dmabuf(&ctrl->dbbuf.doorbells);
+		iommu_put_dmabuf(&ctrl->dbbuf.eventidxs);
 	}
 
 	vfio_pci_unmap_bar(&ctrl->pci, 0, ctrl->regs, 0x1000, 0);

--- a/src/nvme/meson.build
+++ b/src/nvme/meson.build
@@ -14,7 +14,7 @@ nvme_sources = files(
 )
 
 # tests
-rq_test = executable('rq_test', [gen_sources, support_sources, trace_sources, 'queue.c', 'util.c', 'rq_test.c'],
+rq_test = executable('rq_test', [gen_sources, support_sources, trace_sources, 'queue.c', 'rq_test.c'],
   link_with: [ccan_lib],
   include_directories: [ccan_inc, core_inc, vfn_inc],
 )

--- a/src/nvme/queue.c
+++ b/src/nvme/queue.c
@@ -26,14 +26,9 @@
 
 #include <linux/vfio.h>
 
-#include <vfn/support/barrier.h>
-#include <vfn/support/compiler.h>
-#include <vfn/support/endian.h>
-#include <vfn/support/mmio.h>
-#include <vfn/support/ticks.h>
+#include <vfn/support.h>
 #include <vfn/trace.h>
-#include <vfn/nvme/types.h>
-#include <vfn/nvme/queue.h>
+#include <vfn/nvme.h>
 
 #include "ccan/time/time.h"
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -48,13 +48,6 @@ uint64_t nvme_crc64(uint64_t crc, const unsigned char *buffer, size_t len)
 	return crc ^ (uint64_t)~0;
 }
 
-int nvme_set_errno_from_cqe(struct nvme_cqe *cqe)
-{
-	errno = le16_to_cpu(cqe->sfp) >> 1 ? EIO : 0;
-
-	return errno ? -1 : 0;
-}
-
 int nvme_aer(struct nvme_ctrl *ctrl, void *opaque)
 {
 	struct nvme_rq *rq;

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -29,7 +29,6 @@
 #include <linux/vfio.h>
 
 #include <vfn/support.h>
-#include <vfn/iommu.h>
 #include <vfn/vfio.h>
 #include <vfn/trace.h>
 #include <vfn/nvme.h>


### PR DESCRIPTION
This PR tracks preparations for merging the [DriverKit backend](https://github.com/SamsungDS/libvfn/pull/10).

The first part of this is the new `iommu_dmabuf` API. This encapsulates memory allocation and mapping which should remove the need for the opaque pointer changes to `iommu_map_vaddr` and the `pgmap` APIs. Instead, the DriverKit backend can implement its own version of the iommu_dmabuf API.