### PR TITLE
nvme: export nvme_configure_[sq|cq] to public

### DIFF
--- a/include/vfn/nvme/ctrl.h
+++ b/include/vfn/nvme/ctrl.h
@@ -228,6 +228,38 @@ int nvme_configure_adminq(struct nvme_ctrl *ctrl, unsigned long sq_flags);
 int nvme_enable(struct nvme_ctrl *ctrl);
 
 /**
+ * nvme_configure_sq - Initialize a SQ instance whose qid is given @qid
+ * @ctrl: See &struct nvme_ctrl
+ * @qid: Queue identifier
+ * @qsize: Queue size
+ * @cq: Associated I/O Completion Queue
+ * @flags: See &enum nvme_create_iosq_flags
+ *
+ * Initialize SQ instance attributes and doorbell.  It does not issue Create
+ * I/O SQ admin commmand to controller, instead it just initializes SQ
+ * instance.
+ *
+ * Return: ``0`` on success, ``-1`` on error and set ``errno``.
+ */
+int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
+		      struct nvme_cq *cq, unsigned long flags);
+
+/**
+ * nvme_configure_cq - Initialize a CQ instance whose qid is given @qid
+ * @ctrl: See &struct nvme_ctrl
+ * @qid: Queue identifier
+ * @qsize: Queue size
+ * @vector: interrupt vector
+ *
+ * Initialize CQ instance attributes and doorbell.  It does not issue Create
+ * I/O CQ admin commmand to controller, instead it just initializes CQ
+ * instance.
+ *
+ * Return: ``0`` on success, ``-1`` on error and set ``errno``.
+ */
+int nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector);
+
+/**
  * nvme_create_iocq - Create an I/O Completion Queue
  * @ctrl: Controller reference
  * @qid: Queue identifier

--- a/src/nvme/core.c
+++ b/src/nvme/core.c
@@ -110,7 +110,7 @@ int nvme_del_ctrl(struct nvme_ctrl *ctrl)
 	return 0;
 }
 
-static int nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector)
+int nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector)
 {
 	struct nvme_cq *cq = &ctrl->cq[qid];
 	uint64_t cap;
@@ -181,8 +181,8 @@ void nvme_discard_cq(struct nvme_ctrl *ctrl, struct nvme_cq *cq)
 	memset(cq, 0x0, sizeof(*cq));
 }
 
-static int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
-			     struct nvme_cq *cq, unsigned long UNUSED flags)
+int nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
+		      struct nvme_cq *cq, unsigned long UNUSED flags)
 {
 	struct nvme_sq *sq = &ctrl->sq[qid];
 	uint64_t cap;


### PR DESCRIPTION
These two functions configure libvfn queue instance attribute members along with doorbell.  They have been inside of nvme_configure_adminq() and nvme_create_io[sq|cq]() APIs where NVMe admin command is actually issued to the admin submission queue and CQE of the command is reaped in the same context by polling in __admin().

However, in case application enabled interrupt for the admin completion queue with vector == 0 and application handles the interrupt in the user-space, CQ entry should not be directly reaped by libvfn, instead application should awake and reap the cq entry once the interrupt comes.

To let application handles cq entries for the admin completion queue by themselves, this patch exported them to public APIs so that application can configure the sq/cq instances in libvfn and issue the admin command and handles the completion properly.