### PR TITLE
Add Kernel headers in the flake package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717281328,
-        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
+        "lastModified": 1742751704,
+        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
+        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,7 @@
 {
   description = "provides the libvfn package for NixOS and Nix environments";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
   };
 
   outputs = { self, nixpkgs }:
@@ -18,6 +17,7 @@
     in {
       formatter = forAllSystems ({ pkgs }: pkgs.nixfmt);
       packages = forAllSystems ({ pkgs }: rec {
+        kernelHeaders = pkgs.linuxHeaders;
         libvfn = pkgs.stdenv.mkDerivation {
           pname = "libvfn";
           version = libvfnVersion;
@@ -26,6 +26,7 @@
             "-Ddocs=disabled"
             "-Dlibnvme=disabled"
             "-Dprofiling=false"
+            "-Dlinux-headers=${kernelHeaders}/include"
           ];
           nativeBuildInputs = with pkgs; [ meson ninja pkg-config perl ];
         };


### PR DESCRIPTION
Having the Linux headers available is necessary to activate the IOMMUFD path. This patch does not activate the path by default as nixos 24.11 still has a kernel that is too old (6.10), but it adds the reference in the flake so it is ready for when the next stable nixos version comes out.