### PR TITLE
iommu/vfio: reset @group->fd when closing vfio group

### DIFF
--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -477,6 +477,7 @@ static int vfio_put_device_fd(struct iommu_ctx *ctx, const char *bdf)
 
 	if (atomic_dec_fetch(&group->nr_devs) == 0) {
 		close(group->fd);
+		group->fd = -1;
 
 		/*
 		 * Kernel vfio driver will remove IOMMU driver and data from


### PR DESCRIPTION
When closing vfio group by a last owner, we should reset @group->fd = -1 as Commit cef9f6d60d05 ("iommu/vfio: fix get vfio group logic") started checking @group->fd is -1 or not to give pre-open group fd back. Otherwise, the following scenario will fail due to invalid file descriptor which has already been closed at the next open time.

	vfio_pci_open()
	vfio_pci_close()
	vfio_pci_open()

Fixes: cef9f6d60d05 ("iommu/vfio: fix get vfio group logic")