### PR TITLE
iommu: add `iommu_translate_iova` to get @vaddr

### DIFF
--- a/include/vfn/iommu.h
+++ b/include/vfn/iommu.h
@@ -20,6 +20,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include <linux/types.h>
 

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -99,6 +99,20 @@ struct iommu_iova_range {
 bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, uint64_t *iova);
 
 /**
+ * iommu_translate_iova - Translate a I/O virtual address into a virtual address
+ * @ctx: &struct iommu_ctx
+ * @iova: I/O virtual address
+ * @vaddr: output parameter
+ *
+ * Iterate the iova map within the iommu context to lookup and translate the given
+ * I/O virtual address into a CPU virtual address.
+ *
+ * Return: > 0 remain size of the map from @vaddr on success, ``-1`` on error
+ * and sets ``errno``.
+ */
+ssize_t iommu_translate_iova(struct iommu_ctx *ctx, uint64_t iova, void **vaddr);
+
+/**
  * iommu_get_iova_ranges - Get iova ranges
  * @ctx: &struct iommu_ctx
  * @ranges: output parameter


### PR DESCRIPTION
We've provided `iommu_translate_vaddr()` to transate a given @vaddr to an I/O virtual memory mapped in IOMMU mapping table.  Sometimes, application might want to translate the opposite: iova -> vaddr.

Add `iommu_translate_iova()` as a public API for application to translate @iova to @vaddr by iterating IOMMU mapping table(skiplist) and check the range with the given @iova.