### PR TITLE
iommu/vfio: introduce best-fit iova allocation

### DIFF
--- a/src/util/skiplist.h
+++ b/src/util/skiplist.h
@@ -54,6 +54,12 @@ void skiplist_clear_with(struct skiplist *list, skiplist_iter_fn fn, void *opaqu
 struct skiplist_node *skiplist_find(struct skiplist *list, const void *key,
 				    int (*cmp)(const void *key, const struct skiplist_node *n),
 				    struct skiplist_node **path);
+struct skiplist_node *skiplist_find_le(struct skiplist *list, const void *key,
+				       int (*cmp)(const void *key, const struct skiplist_node *n),
+				       struct skiplist_node **path);
+struct skiplist_node *skiplist_find_ge(struct skiplist *list, const void *key,
+				       int (*cmp)(const void *key, const struct skiplist_node *n),
+				       struct skiplist_node **path);
 void skiplist_link(struct skiplist *list, struct skiplist_node *n,
 		   struct skiplist_node *update[SKIPLIST_LEVELS]);
 void skiplist_erase(struct skiplist *list, struct skiplist_node *n,

--- a/src/util/skiplist_test.c
+++ b/src/util/skiplist_test.c
@@ -98,7 +98,7 @@ int main(int argc UNUSED, char *argv[] UNUSED)
 	struct skiplist_node *n, *update[SKIPLIST_LEVELS];
 	unsigned int v;
 
-	plan_tests(21);
+	plan_tests(31);
 
 	skiplist_init(&list);
 
@@ -151,6 +151,48 @@ int main(int argc UNUSED, char *argv[] UNUSED)
 	skiplist_erase(&list, n, update);
 
 	ok(skiplist_find(&list, &v, __cmp, NULL) == NULL, "find 0 not ok");
+
+	/* Test skiplist_find_le - list currently has [1, 2, 3] */
+	v = 2;
+	n = skiplist_find_le(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 2, "find_le(2) returns 2");
+
+	v = 4;
+	n = skiplist_find_le(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 3, "find_le(4) returns 3");
+
+	v = 0;
+	n = skiplist_find_le(&list, &v, __cmp, NULL);
+	ok(n == NULL, "find_le(0) returns NULL (no values <= 0)");
+
+	v = 1;
+	n = skiplist_find_le(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 1, "find_le(1) returns 1");
+
+	v = 3;
+	n = skiplist_find_le(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 3, "find_le(3) returns 3");
+
+	/* Test skiplist_find_ge - list currently has [1, 2, 3] */
+	v = 2;
+	n = skiplist_find_ge(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 2, "find_ge(2) returns 2");
+
+	v = 0;
+	n = skiplist_find_ge(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 1, "find_ge(0) returns 1");
+
+	v = 4;
+	n = skiplist_find_ge(&list, &v, __cmp, NULL);
+	ok(n == NULL, "find_ge(4) returns NULL (no values >= 4)");
+
+	v = 1;
+	n = skiplist_find_ge(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 1, "find_ge(1) returns 1");
+
+	v = 3;
+	n = skiplist_find_ge(&list, &v, __cmp, NULL);
+	ok(n && skiplist_entry(n, struct entry, list)->v == 3, "find_ge(3) returns 3");
 
 	return exit_status();
 }


### PR DESCRIPTION
    Introduce a best-fit IOVA allocation policy to vfio_iommu_type1 device
    to reuse previously allocated and freed IOVA ranges in the next
    allocation.  Unlike `iommufd` which allocates the IOVA address in the
    kernel side, `vfio_iommu_type1` device should manage the IOVA ranges in
    libvfn to avoid permanently incremental memory allocation for a
    long-lived application like ``unvme-cli``.

    Firstly try to allocate from @free_iovas skiplist for a new IOVA
    allocation with a best-fit allocation method, and if not, it goes to the
    previous way with `__iova_reserve()`.  Other than this, no functional
    changes.
