### PR TITLE
Fix potential tear-down bug

### DIFF
--- a/include/vfn/nvme/ctrl.h
+++ b/include/vfn/nvme/ctrl.h
@@ -371,7 +371,9 @@ int nvme_create_iocq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector);
  * @ctrl: See &struct nvme_ctrl
  * @qid: Queue identifier
  *
- * Delete the I/O Completion queue associated with @qid.
+ * Delete the I/O Completion queue associated with @qid. The queue's
+ * host-side resources are only freed once the device has confirmed the
+ * queue is gone, rather than before asking it to delete the queue.
  *
  * Return: On success, returns ``0``. On error, returns ``-1`` and sets
  * ``errno``.
@@ -404,7 +406,11 @@ int nvme_create_iosq(struct nvme_ctrl *ctrl, int qid, int qsize,
  * @ctrl: See &struct nvme_ctrl
  * @qid: Queue identifier
  *
- * Delete the I/O Submission queue associated with @qid.
+ * Delete the I/O Submission queue associated with @qid. Deleting a
+ * submission queue aborts any command still outstanding on it, and its
+ * host-side resources (including its request trackers) are only freed
+ * once the device has confirmed this, so a request tracker acquired from
+ * this queue remains valid to release until this call returns.
  *
  * Return: On success, returns ``0``. On error, returns ``-1`` and sets
  * ``errno``.
@@ -437,7 +443,9 @@ int nvme_create_ioqpair(struct nvme_ctrl *ctrl, int qid, int qsize, int vector,
  * @ctrl: See &struct nvme_ctrl
  * @qid: Queue identifier
  *
- * Delete both the I/O Submission and Completion queues associated with @qid.
+ * Delete both the I/O Submission and Completion queues associated with
+ * @qid (see &nvme_delete_iosq for what this guarantees about commands
+ * still outstanding on the pair).
  *
  * Return: On success, returns ``0``. On error, returns ``-1`` and sets
  * ``errno``.

--- a/src/nvme/core.c
+++ b/src/nvme/core.c
@@ -443,15 +443,20 @@ int nvme_create_iocq(struct nvme_ctrl *ctrl, int qid, int qsize, int vector)
 int nvme_delete_iocq(struct nvme_ctrl *ctrl, int qid)
 {
 	union nvme_cmd cmd;
-
-	nvme_discard_cq(ctrl, &ctrl->cq[qid]);
+	int ret;
 
 	cmd.delete_q = (struct nvme_cmd_delete_q) {
 		.opcode = NVME_ADMIN_DELETE_CQ,
 		.qid = cpu_to_le16((uint16_t)qid),
 	};
 
-	return __admin(ctrl, &cmd);
+	ret = __admin(ctrl, &cmd);
+	if (ret)
+		return ret;
+
+	nvme_discard_cq(ctrl, &ctrl->cq[qid]);
+
+	return 0;
 }
 
 int nvme_create_iosq(struct nvme_ctrl *ctrl, int qid, int qsize, struct nvme_cq *cq,
@@ -480,15 +485,20 @@ int nvme_create_iosq(struct nvme_ctrl *ctrl, int qid, int qsize, struct nvme_cq 
 int nvme_delete_iosq(struct nvme_ctrl *ctrl, int qid)
 {
 	union nvme_cmd cmd;
-
-	nvme_discard_sq(ctrl, &ctrl->sq[qid]);
+	int ret;
 
 	cmd.delete_q = (struct nvme_cmd_delete_q) {
 		.opcode = NVME_ADMIN_DELETE_SQ,
 		.qid = cpu_to_le16((uint16_t)qid),
 	};
 
-	return __admin(ctrl, &cmd);
+	ret = __admin(ctrl, &cmd);
+	if (ret)
+		return ret;
+
+	nvme_discard_sq(ctrl, &ctrl->sq[qid]);
+
+	return 0;
 }
 
 int nvme_create_ioqpair(struct nvme_ctrl *ctrl, int qid, int qsize, int vector, unsigned long flags)


### PR DESCRIPTION
We've been using Claude a bit on this code base and it found this real, though somewhat niche bug: if a device is torn down while there is still work in the queue the hardware may write to memory that has already been freed. 

In most cases I expect the process will soon be excited when this happens so there's likely not much harm, but I thought it was worth sending Claude's solution for it so the code is correct here.
