### PR TITLE
ccan/meson: fix ccan/minmax compilation error with -Wall

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -123,7 +123,7 @@ ccan_config.set10('HAVE_SYS_UNISTD_H',
 ccan_config.set10('HAVE_TYPEOF',
   cc.compiles('''
     int main(void) {
-      int x;
+      int x = 0;
       __typeof__(x) y;
       y = x;
       return y == x ? 0 : 1;


### PR DESCRIPTION
When compiling with -Wall in Rockylinux 9.8, compilation fails with:

    In file included from ../src/nvme/util.c:36:
    ../ccan/ccan/minmax/minmax.h:14:2: error: #error Sorry, minmax module requires statement expressions and typeof

This was tracked to an error in meson.build, with the following in the meson-log.txt:

    testfile.c:5:9: error: 'x' is used uninitialized [-Werror=uninitialized]
      5 |       y = x;
        |       ~~^~~

Fix by initializing said variable.