### PR TITLE
A couple more minor bug fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Issuing a crafted command using the high-level API can be as simple as:
 
      nvme_admin(&ctrl, &cmd, vaddr, NVME_IDENTIFY_DATA_SIZE, NULL);
 
-     printf("vid 0x%"PRIx8"\n", ((struct nvme_id_ctrl *)vaddr)->vid);
+     printf("vid 0x%"PRIx16"\n", ((struct nvme_id_ctrl *)vaddr)->vid);
 
      return 0;
    }

--- a/examples/identify.c
+++ b/examples/identify.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 	case NVME_IDENTIFY_CNS_CTRL:
 		id_ctrl = vaddr;
 
-		printf("vid 0x%"PRIx8"\n", id_ctrl->vid);
+		printf("vid 0x%"PRIx16"\n", id_ctrl->vid);
 
 		break;
 

--- a/examples/regs.c
+++ b/examples/regs.c
@@ -106,9 +106,9 @@ int main(int argc, char **argv)
 	printf("%-16s %lx\n",  "CAP.PMRS", NVME_CAP_PMRS(cap));
 
 	printf("%-16s %x\n",   "VS", vs);
-	printf("%-16s %x\n",   "VS.MJR", NVME_VS_TER(vs));
+	printf("%-16s %x\n",   "VS.MJR", NVME_VS_MJR(vs));
 	printf("%-16s %x\n",   "VS.MNR", NVME_VS_MNR(vs));
-	printf("%-16s %x\n",   "VS.TER", NVME_VS_MJR(vs));
+	printf("%-16s %x\n",   "VS.TER", NVME_VS_TER(vs));
 
 	printf("%-16s %x\n",   "INTMS", intms);
 	printf("%-16s %x\n",   "INTMC", intmc);


### PR DESCRIPTION
We noticed a couple more minor issues in the code the other day and made a couple patches for them:

1. Use the correct format specifier when printing the vid. It is a 16bit value but was printed with an 8 bit specifier in the README example and identify.c

2. In regs.c, VS_TERM and VS_MJR were incorrectly ordered